### PR TITLE
[WIP] Add a minimal environment.yml

### DIFF
--- a/reinvent_minimal.yml
+++ b/reinvent_minimal.yml
@@ -1,0 +1,21 @@
+name: reinvent_shared.v2.1
+channels:
+  - rdkit
+  - pytorch
+  - omnia
+  - anaconda
+  - conda-forge
+  - defaults
+dependencies:
+  - pytorch==1.3.1
+  - requests==2.22.0
+  - dataclasses==0.7
+  - pandas==0.25.3
+  - tqdm==4.38.0
+  - numpy==1.17.3
+  - scipy==1.3.2
+  - scikit-learn==0.21.3
+  - pathos==0.2.5
+  - rdkit==2019.09.1
+  - tensorboard==1.14.0
+  - pytest==5.3.0


### PR DESCRIPTION
(addresses #5)
 
This adds a minimal environment.yml such it can be installed on Windows and Mac systems. Also, this removes a lot of unnecessary and unused packages from `reinvent-shared.yml` (e.g. Jedi, deepsmiles, ...).

I still have to fully test this environment on Windows. 
On macOS we pass the UnitTests with the "normal" warnings about future deprecations in tensorboard and the version mismatch of the sklearn models. 

We should think if we want to add openeye-toolkits to the dependencies or not. It's technically not needed in the framework but a lot of scoring functions need this. 

Also, we should think about if we want to add `cudatoolkits` to this or not. For RL one does not necessarily need GPU support, even though it makes everything a lot faster. However, this would break macOS compatibility as there are no recent `cudatoolkits` packages in conda. 

